### PR TITLE
Add support for macOS clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ sudo apt install --no-install-recommends \
         libany-uri-escape-perl \
         libmojolicious-perl \
         libfile-slurper-perl \
-        liblcms2-2
+        liblcms2-2 \
+        wget
 ```
 
 A separate Python's virtualenv will be stored to `/var/lib/immich`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository provides instructions and helper scripts to install [Immich](htt
 
  * This guide installs Immich to `/var/lib/immich`. To change it, replace it to the directory you want in this README and `install.sh`'s `$IMMICH_PATH`.
 
- * The [install.sh](install.sh) script currently is using Immich v1.106.2. It should be noted that due to the fast-evolving nature of Immich, the install script may get broken if you replace the `$TAG` to something more recent.
+ * The [install.sh](install.sh) script currently is using Immich v1.106.3. It should be noted that due to the fast-evolving nature of Immich, the install script may get broken if you replace the `$TAG` to something more recent.
 
  * `mimalloc` is deliberately disabled as this is a native install and sharing system library makes more sense.
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ This repository provides instructions and helper scripts to install [Immich](htt
 
  * This is tested on Ubuntu 22.04 (on both x86 and aarch64) as the host distro, but it will be similar on other distros.
 
- * If your distro is not running Python v3.10 or v3.11 (e.g., Ubuntu 24.04), you may need to force a poetry update. Find `if false` in `install.sh`, and set it to true.
-
  * This guide installs Immich to `/var/lib/immich`. To change it, replace it to the directory you want in this README and `install.sh`'s `$IMMICH_PATH`.
 
  * The [install.sh](install.sh) script currently is using Immich v1.105.1. It should be noted that due to the fast-evolving nature of Immich, the install script may get broken if you replace the `$TAG` to something more recent.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository provides instructions and helper scripts to install [Immich](htt
 
  * This guide installs Immich to `/var/lib/immich`. To change it, replace it to the directory you want in this README and `install.sh`'s `$IMMICH_PATH`.
 
- * The [install.sh](install.sh) script currently is using Immich v1.105.1. It should be noted that due to the fast-evolving nature of Immich, the install script may get broken if you replace the `$TAG` to something more recent.
+ * The [install.sh](install.sh) script currently is using Immich v1.106.2. It should be noted that due to the fast-evolving nature of Immich, the install script may get broken if you replace the `$TAG` to something more recent.
 
  * `mimalloc` is deliberately disabled as this is a native install and sharing system library makes more sense.
 

--- a/immich-machine-learning.service
+++ b/immich-machine-learning.service
@@ -7,6 +7,7 @@ User=immich
 Group=immich
 Type=simple
 Restart=on-failure
+UMask=0077
 
 WorkingDirectory=/var/lib/immich/app
 EnvironmentFile=/var/lib/immich/env

--- a/immich-microservices.service
+++ b/immich-microservices.service
@@ -9,6 +9,7 @@ User=immich
 Group=immich
 Type=simple
 Restart=on-failure
+UMask=0077
 
 WorkingDirectory=/var/lib/immich/app
 EnvironmentFile=/var/lib/immich/env

--- a/immich.service
+++ b/immich.service
@@ -11,6 +11,7 @@ User=immich
 Group=immich
 Type=simple
 Restart=on-failure
+UMask=0077
 
 WorkingDirectory=/var/lib/immich/app
 EnvironmentFile=/var/lib/immich/env

--- a/install.sh
+++ b/install.sh
@@ -79,7 +79,8 @@ python3 -m venv $APP/machine-learning/venv
   . $APP/machine-learning/venv/bin/activate
   pip3 install poetry
   cd machine-learning
-  if false; then # Set this to true to force poetry update
+  if python -c 'import sys; exit(0) if sys.version_info.major == 3 and sys.version_info.minor > 11 else exit(1)'; then
+    echo "Python > 3.11 detected, forcing poetry update"
     # Allow Python 3.12 (e.g., Ubuntu 24.04)
     sed -i -e 's/<3.12/<4/g' pyproject.toml
     poetry update

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 set -xeuo pipefail
 
-TAG=v1.105.1
+TAG=v1.106.2
 
 IMMICH_PATH=/var/lib/immich
 APP=$IMMICH_PATH/app

--- a/install.sh
+++ b/install.sh
@@ -29,6 +29,7 @@ if [[ "$USER" != "immich" ]]; then
 fi
 
 BASEDIR=$(dirname "$0")
+umask 077
 
 rm -rf $APP
 mkdir -p $APP
@@ -37,6 +38,7 @@ mkdir -p $APP
 # This expects immich user's home directory to be on $IMMICH_PATH/home
 rm -rf $IMMICH_PATH/home
 mkdir -p $IMMICH_PATH/home
+echo 'umask 077' > $IMMICH_PATH/home/.bashrc
 
 TMP=/tmp/immich-$(uuidgen)
 git clone https://github.com/immich-app/immich $TMP

--- a/install.sh
+++ b/install.sh
@@ -96,6 +96,16 @@ ln -sf $IMMICH_PATH/app/resources $IMMICH_PATH/
 mkdir -p $IMMICH_PATH/cache
 sed -i -e "s@\"/cache\"@\"$IMMICH_PATH/cache\"@g" $APP/machine-learning/app/config.py
 
+# Install GeoNames
+cd $IMMICH_PATH/app/resources
+wget -o - https://download.geonames.org/export/dump/admin1CodesASCII.txt &
+wget -o - https://download.geonames.org/export/dump/admin2Codes.txt &
+wget -o - https://download.geonames.org/export/dump/cities500.zip &
+wait
+unzip cities500.zip
+date --iso-8601=seconds | tr -d "\n" > geodata-date.txt
+rm cities500.zip
+
 # Install sharp
 cd $APP
 npm install sharp

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 set -xeuo pipefail
 
-TAG=v1.106.2
+TAG=v1.106.3
 
 IMMICH_PATH=/var/lib/immich
 APP=$IMMICH_PATH/app


### PR DESCRIPTION
This PR adds support for native installation of immich on macOS environments.

It also adds the ability to automatically install the service files and launching of the service (currently only enabled for macOS - Linux behaviour is unchanged)