### PR TITLE
Fix a require loop

### DIFF
--- a/immich.service
+++ b/immich.service
@@ -4,7 +4,7 @@ Documentation=https://github.com/immich-app/immich
 Requires=redis-server.service
 Requires=postgresql.service
 Requires=immich-machine-learning.service
-Requires=immich.service
+Requires=immich-microservices.service
 
 [Service]
 User=immich


### PR DESCRIPTION
There seems to be a require loop in the service file. I believe it suppose to mean that `immich.service` requires `immich-microservices.service` up and running, but it was written as `immich.service` requires itself up and running.