### PR TITLE
Update README.md to include npm in dependencies to be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ sudo apt install --no-install-recommends \
         libmojolicious-perl \
         libfile-slurper-perl \
         liblcms2-2 \
+        npm \
         wget
 ```
 


### PR DESCRIPTION
Installing on Ubuntu 24.04 LTS, it seems that `npm` dependency needs to be installed explicitly